### PR TITLE
(fix) Update year to 2019 in title, social share

### DIFF
--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -118,11 +118,11 @@ export default class Share extends React.Component {
             <div className="section section-narrow spread-the-word">
                 <h2 className="section-heading">Help Spread the Word!</h2>
                 <div className="share-options">
-                    <Twitter text="The State Of JavaScript Survey: find out the most popular JavaScript technologies of 2018 http://stateofjs.com #stateofjs" />
+                    <Twitter text="The State Of JavaScript Survey: find out the most popular JavaScript technologies of 2019 http://stateofjs.com #stateofjs" />
                     <Facebook link="http://stateofjs.com" />
                     <Email
                         subject="The State Of JavaScript"
-                        body="Find out the most popular JavaScript technologies of 2018: http://stateofjs.com"
+                        body="Find out the most popular JavaScript technologies of 2019: http://stateofjs.com"
                     />
                 </div>
             </div>

--- a/src/layouts/layout.js
+++ b/src/layouts/layout.js
@@ -10,7 +10,7 @@ export default class Layout extends React.Component {
         const description = 'The annual survey about current popular JavaScript technologies.'
         const url = 'http://stateofjs.com'
         const image = 'http://stateofjs.com/images/stateofjs2018-social-media.png'
-        const title = 'The State of JavaScript 2018'
+        const title = 'The State of JavaScript 2019'
         const meta = [
             { charset: 'utf-8' },
             { name: 'description', content: description },


### PR DESCRIPTION
Updates the page title, Facebook share text, and email share subject line to reflect the new year.